### PR TITLE
Fixed crash on large binary files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8487,7 +8487,9 @@ const sliceChars = (file, maxTokens) => {
 };
 
 module.exports = (str, maxTokens) => {
-  const files = str.split(new RegExp(`\n${FILES_SPLIT}`, 'g'));
+  // Remove binary patches as they are not needed and can be very large.
+  const formated = str.replace(/(?:GIT binary patch)(\ndelta.*\s*)(?:[diff --git]|$)/gmsu, 'GIT binary patch');
+  const files = formated.split(new RegExp(`\n${FILES_SPLIT}`, 'g'));
   files.sort((a, b) => a.length - b.length);
 
   let tokens = 0;
@@ -12608,7 +12610,7 @@ module.exports = function bind(fn, thisArg) {
 /***/ 731:
 /***/ (function(module) {
 
-module.exports = {"name":"recap","version":"1.0.0","description":"Github action to summarize the most important changes in a pull request","main":"dist/index.js","scripts":{"build":"eslint src && ncc build src/entrypoint.js","test":"jest","lint":"eslint ./"},"keywords":[],"author":"Manuel de la Torre","license":"MIT","jest":{"testEnvironment":"node","setupFilesAfterEnv":["./tests/setup.js"],"testMatch":["**/?(*.)+(spec|test).[jt]s?(x)"]},"dependencies":{"@actions/core":"^1.5.0","@actions/github":"^5.0.0","axios":"^0.26.1","i18n-js":"^3.9.2","lodash.get":"^4.4.2","mixpanel":"^0.13.0"},"devDependencies":{"@zeit/ncc":"^0.22.3","eslint":"^7.32.0","eslint-config-airbnb-base":"^14.2.1","eslint-plugin-import":"^2.24.1","eslint-plugin-jest":"^24.4.0","jest":"^27.0.6","jest-extended":"^3.2.4","nock":"^13.3.0"},"funding":"https://github.com/sponsors/manuelmhtr"};
+module.exports = {"name":"recap","version":"1.0.1","description":"Github action to summarize the most important changes in a pull request","main":"dist/index.js","scripts":{"build":"eslint src && ncc build src/entrypoint.js","test":"jest","lint":"eslint ./"},"keywords":[],"author":"Manuel de la Torre","license":"MIT","jest":{"testEnvironment":"node","setupFilesAfterEnv":["./tests/setup.js"],"testMatch":["**/?(*.)+(spec|test).[jt]s?(x)"]},"dependencies":{"@actions/core":"^1.5.0","@actions/github":"^5.0.0","axios":"^0.26.1","i18n-js":"^3.9.2","lodash.get":"^4.4.2","mixpanel":"^0.13.0"},"devDependencies":{"@zeit/ncc":"^0.22.3","eslint":"^7.32.0","eslint-config-airbnb-base":"^14.2.1","eslint-plugin-import":"^2.24.1","eslint-plugin-jest":"^24.4.0","jest":"^27.0.6","jest-extended":"^3.2.4","nock":"^13.3.0"},"funding":"https://github.com/sponsors/manuelmhtr"};
 
 /***/ }),
 

--- a/src/utils/limitTokens.js
+++ b/src/utils/limitTokens.js
@@ -9,7 +9,9 @@ const sliceChars = (file, maxTokens) => {
 };
 
 module.exports = (str, maxTokens) => {
-  const files = str.split(new RegExp(`\n${FILES_SPLIT}`, 'g'));
+  // Remove binary patches as they are not needed and can be very large.
+  const formated = str.replace(/(?:GIT binary patch\s*)(delta.*\s*)(?:[diff --git]|$)/gmus, '');
+  const files = formated.split(new RegExp(`\n${FILES_SPLIT}`, 'g'));
   files.sort((a, b) => a.length - b.length);
 
   let tokens = 0;

--- a/src/utils/limitTokens.js
+++ b/src/utils/limitTokens.js
@@ -10,7 +10,7 @@ const sliceChars = (file, maxTokens) => {
 
 module.exports = (str, maxTokens) => {
   // Remove binary patches as they are not needed and can be very large.
-  const formated = str.replace(/(?:GIT binary patch\s*)(delta.*\s*)(?:[diff --git]|$)/gmus, '');
+  const formated = str.replace(/(?:GIT binary patch)(\ndelta.*\s*)(?:[diff --git]|$)/gmsu, 'GIT binary patch');
   const files = formated.split(new RegExp(`\n${FILES_SPLIT}`, 'g'));
   files.sort((a, b) => a.length - b.length);
 


### PR DESCRIPTION
Great work on building this project! I recently discovered that committing large binary files can still cause a crash. Upon further investigation, I found that the issue stems from the binary data being encoded as text within the patch string.

To address this issue, I propose removing the unnecessary encoding of binary data before slicing the array for processing by ChatGPT. This should effectively prevent the crash when committing large files.

While this approach may prioritize binary files over other changes due to the commit list being sorted by length, the same issue can occur with large code changes. To further improve the function, we could consider sending a request to OpenAI for each `diff --git` command and then combining the results to build the summary later. This would help to avoid dismissing significant changes based solely on their length and ensure that changes are ranked by relevance.